### PR TITLE
chore: update tstyche to v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "installed-check": "^10.0.0",
     "knip": "^5.83.1",
     "npm-run-all2": "^8.0.4",
-    "tstyche": "^6.2.0",
+    "tstyche": "^7.0.0",
     "type-coverage": "^2.29.7",
     "typescript": "~5.9.3",
     "validate-conventional-commit": "^1.0.4"

--- a/typetests/declaration-types.test.ts
+++ b/typetests/declaration-types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, type _ } from 'tstyche';
+import {
+  type _, describe, expect, it,
+} from 'tstyche';
 
 import type {
   AnyDeclaration,

--- a/typetests/declaration-types.test.ts
+++ b/typetests/declaration-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, it, expect, type _ } from 'tstyche';
 
 import type {
   AnyDeclaration,
@@ -52,12 +52,12 @@ describe('ValidDeclaration', () => {
     expect<ValidDeclaration<'Input', TestDeclarations>['type']>().type.toBe<'Input'>();
   });
 
-  it('should raise error when type name does not exist in declarations', () => {
-    expect<ValidDeclaration<'NonExistent', TestDeclarations>>().type.toRaiseError();
+  it('should not be instantiable with type name that does not exist in declarations', () => {
+    expect<ValidDeclaration<_, _>>().type.not.toBeInstantiableWith<['NonExistent', TestDeclarations]>();
   });
 
-  it('should raise error when using generic string instead of literal', () => {
-    expect<ValidDeclaration<string, TestDeclarations>>().type.toRaiseError();
+  it('should not be instantiable with generic string instead of literal', () => {
+    expect<ValidDeclaration<_, _>>().type.not.toBeInstantiableWith<[string, TestDeclarations]>();
   });
 });
 

--- a/typetests/function-types.test.ts
+++ b/typetests/function-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, it, expect, type _ } from 'tstyche';
 
 import type {
   ParametersWithoutTheFirst,
@@ -21,9 +21,9 @@ describe('ParametersWithoutTheFirst', () => {
     expect<ParametersWithoutTheFirst<TestFunc>>().type.toBe<never>();
   });
 
-  it('should raise error for non-function types', () => {
-    expect<ParametersWithoutTheFirst<string>>().type.toRaiseError();
-    expect<ParametersWithoutTheFirst<number>>().type.toRaiseError();
+  it('should not be instantiable with non-function types', () => {
+    expect<ParametersWithoutTheFirst<_>>().type.not.toBeInstantiableWith<[string]>();
+    expect<ParametersWithoutTheFirst<_>>().type.not.toBeInstantiableWith<[number]>();
   });
 });
 
@@ -53,7 +53,7 @@ describe('FunctionWithoutFirstParameter', () => {
   });
 
   it('should raise error for non-function types', () => {
-    expect<FunctionWithoutFirstParameter<string>>().type.toRaiseError();
-    expect<FunctionWithoutFirstParameter<number>>().type.toRaiseError();
+    expect<FunctionWithoutFirstParameter<_>>().type.not.toBeInstantiableWith<[string]>();
+    expect<FunctionWithoutFirstParameter<_>>().type.not.toBeInstantiableWith<[number]>();
   });
 });

--- a/typetests/function-types.test.ts
+++ b/typetests/function-types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, type _ } from 'tstyche';
+import {
+  type _, describe, expect, it,
+} from 'tstyche';
 
 import type {
   FunctionWithoutFirstParameter,

--- a/typetests/object-types.test.ts
+++ b/typetests/object-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, it, expect, type _ } from 'tstyche';
 
 import type {
   ObjectEntries,
@@ -14,9 +14,9 @@ describe('ObjectEntry', () => {
     expect<ObjectEntry<{ a: string; b: number }>>().type.toBe<['a', string] | ['b', number]>();
   });
 
-  it('should raise error for non-object types', () => {
-    expect<ObjectEntry<string>>().type.toRaiseError();
-    expect<ObjectEntry<number>>().type.toRaiseError();
+  it('should not be instantiable with non-object types', () => {
+    expect<ObjectEntry<_>>().type.not.toBeInstantiableWith<[string]>();
+    expect<ObjectEntry<_>>().type.not.toBeInstantiableWith<[number]>();
   });
 });
 
@@ -51,9 +51,9 @@ describe('PartialKeys', () => {
     expect<Result>().type.toBeAssignableTo<{ a?: string; b?: number; c: boolean }>();
   });
 
-  it('should raise error when key does not exist in object', () => {
+  it('should not be instantiable with key that does not exist in object', () => {
     type TestObject = { a: string; b: number };
-    expect<PartialKeys<TestObject, 'nonexistent'>>().type.toRaiseError();
+    expect<PartialKeys<_, _>>().type.not.toBeInstantiableWith<[TestObject, 'nonexistent']>();
   });
 });
 

--- a/typetests/object-types.test.ts
+++ b/typetests/object-types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, type _ } from 'tstyche';
+import {
+  type _, describe, expect, it,
+} from 'tstyche';
 
 import type {
   IsEmptyObject,

--- a/typetests/string-types.test.ts
+++ b/typetests/string-types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it } from 'tstyche';
+import {
+  type _, describe, expect, it,
+} from 'tstyche';
 
 import type {
   LiteralStringUnion,
@@ -72,9 +74,9 @@ describe('LiteralStringUnion', () => {
     expect<Status>().type.toBeAssignableTo<string>();
   });
 
-  it('should raise an error for non-string type arguments', () => {
-    expect<LiteralStringUnion<number>>().type.toRaiseError();
-    expect<LiteralStringUnion<boolean>>().type.toRaiseError();
+  it('should not be instantiable with non-string type arguments', () => {
+    expect<LiteralStringUnion<_>>().type.not.toBeInstantiableWith<[number]>();
+    expect<LiteralStringUnion<_>>().type.not.toBeInstantiableWith<[boolean]>();
   });
 
   // Edge case

--- a/typetests/verify-types.test.ts
+++ b/typetests/verify-types.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, type _ } from 'tstyche';
+import {
+  type _, describe, expect, it,
+} from 'tstyche';
 
 import type { VerifyObjectHasTypeProperty, VerifySuperset } from '../index.js';
 

--- a/typetests/verify-types.test.ts
+++ b/typetests/verify-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, it, expect, type _ } from 'tstyche';
 
 import type { VerifySuperset, VerifyObjectHasTypeProperty } from '../index.js';
 
@@ -9,8 +9,8 @@ describe('VerifySuperset', () => {
     expect<VerifySuperset<Base, Derived>>().type.toBe<Derived>();
   });
 
-  it('should raise error when type does not extend base', () => {
-    expect<VerifySuperset<{ type: string }, { abc: 123 }>>().type.toRaiseError();
+  it('should not be instantiable with type that does not extend base', () => {
+    expect<VerifySuperset<_, _>>().type.not.toBeInstantiableWith<[{ type: string }, { abc: 123 }]>();
   });
 
   // Edge case
@@ -31,8 +31,8 @@ describe('VerifyObjectHasTypeProperty', () => {
       expect<VerifyObjectHasTypeProperty<{ type: string }>>().type.toBe<{ type: string }>();
     });
 
-    it('should raise error when property is missing', () => {
-      expect<VerifyObjectHasTypeProperty<{ abc: 123 }>>().type.toRaiseError();
+    it('should not be instantiable with property that is missing', () => {
+      expect<VerifyObjectHasTypeProperty<_>>().type.not.toBeInstantiableWith<[{ abc: 123 }]>();
     });
 
     // Edge case
@@ -47,12 +47,12 @@ describe('VerifyObjectHasTypeProperty', () => {
       expect<VerifyObjectHasTypeProperty<{ type: 'foo' }, true>>().type.toBe<{ type: 'foo' }>();
     });
 
-    it('should raise error when type is generic string', () => {
-      expect<VerifyObjectHasTypeProperty<{ type: string }, true>>().type.toRaiseError();
+    it('should not be instantiable with type that is generic string', () => {
+      expect<VerifyObjectHasTypeProperty<_>>().type.not.toBeInstantiableWith<[{ type: string }, true]>();
     });
 
-    it('should raise error when property is missing', () => {
-      expect<VerifyObjectHasTypeProperty<{ abc: 123 }, true>>().type.toRaiseError();
+    it('should not be instantiable with property that is missing', () => {
+      expect<VerifyObjectHasTypeProperty<_>>().type.not.toBeInstantiableWith<[{ abc: 123 }, true]>();
     });
 
     // Edge case


### PR DESCRIPTION
This PR updates TSTyche to v7.0.0. Release notes: https://tstyche.org/releases/tstyche-7

The `.toRaiseError()` matcher is deprecated. I think, after adding `.toBeInstantiableWith()`, most of the cases should be covered by other matchers.

Indeed, `.toBeInstantiableWith()` covers only some edge cases, but sounds to be useful. I wanted to suggest using it here.

Another alternative could be replacing `.toRaiseError()` with `// @ts-expect-error <Error message>`, because TSTyche is able to check the error messages as well.

As you see, there is an overlap between the APIs. This is the main reason to deprecate `.toRaiseError()`.