### PR TITLE
feat: add `LiteralStringUnion`

### DIFF
--- a/.github/workflows/tstyche.yml
+++ b/.github/workflows/tstyche.yml
@@ -1,4 +1,4 @@
-name: Type Checks, Internal Types
+name: Type Tests, tstyche
 
 on:
   push:

--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "entry": ["index.d.ts"],
-  "ignore": ["**/typetests/**/*.test.ts"]
+  "ignore": ["**/typetests/**/*.test.ts"],
+  "ignoreBinaries": ["jq"]
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ function timeToFoo (foo) {
 
 ## String types
 
+* `LiteralStringUnion<Literals>` – a union of the known string literals in `Literals` that still accepts any `string`, keeping the literals as editor suggestions (the string-pinned form of [`type-fest`](https://github.com/sindresorhus/type-fest)'s `LiteralStringUnion` / `LiteralUnion`)
 * `NonGenericString<T, [ErrorMessage]>` – ensures that `T` is not a generic `string` (and as such likely a string literal)
 * `NonGenericStringArray<T, [ErrorMessage]>` – similar to `NonGenericString` but with `T` being an `Array` / `ReadonlyArray`
 

--- a/lib/string-types.d.ts
+++ b/lib/string-types.d.ts
@@ -12,3 +12,32 @@ export type NonGenericStringArray<T, ErrorMessage extends string = never> =
     T extends ReadonlyArray<infer U>
       ? (string extends U ? ErrorMessage : T)
       : T;
+
+/**
+ * A union of known string literals that still accepts *any* string.
+ *
+ * The literals stay visible as editor suggestions (discoverable, self-documenting),
+ * while `string & Record<never, never>` keeps the type open to arbitrary strings.
+ * The intersection prevents TypeScript's eager collapse of the union down to plain
+ * `string`, which is what would otherwise discard the literal suggestions.
+ *
+ * Contrast with {@link NonGenericString}, which takes the opposite stance toward
+ * generic `string`: it rejects it, whereas this embraces it.
+ *
+ * Equivalent to type-fest's `LiteralStringUnion` (`LiteralUnion<T, string>`) plus an
+ * `extends string` constraint. It is a developer-experience helper: the type is
+ * `string`-equivalent, so it gives no type-safety, narrowing, or exhaustiveness
+ * guarantees over `string` – use a closed union when you need those.
+ *
+ * @template Literals - The known string literals to surface as suggestions
+ * @example
+ * type Status = LiteralStringUnion<'SUCCESS' | 'PENDING' | 'FAILED'>;
+ * let a: Status = 'SUCCESS';   // suggested in the editor
+ * let b: Status = 'anything';  // still allowed
+ * @see https://github.com/sindresorhus/type-fest (`LiteralStringUnion` / `LiteralUnion`)
+ * @see https://github.com/microsoft/TypeScript/issues/29729
+ */
+export type LiteralStringUnion<Literals extends string> =
+  | Literals
+  // `{}`-equivalent; `Record<never, never>` avoids `no-empty-object-type` lint in consumer codebases
+  | (string & Record<never, never>);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24",
-    "typescript": ">=5.8"
+    "typescript": ">=5.9"
   },
   "type": "module",
   "types": "./index.d.ts",

--- a/typetests/string-types.test.ts
+++ b/typetests/string-types.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'tstyche';
 import type {
   NonGenericString,
   NonGenericStringArray,
+  LiteralStringUnion,
 } from '../index.js';
 
 describe('NonGenericString', () => {
@@ -44,5 +45,52 @@ describe('NonGenericStringArray', () => {
   it('should allow non-string array types to pass through unchanged', () => {
     expect<NonGenericStringArray<number[]>>().type.toBe<number[]>();
     expect<NonGenericStringArray<boolean[]>>().type.toBe<boolean[]>();
+  });
+});
+
+describe('LiteralStringUnion', () => {
+  type Status = LiteralStringUnion<'SUCCESS' | 'PENDING' | 'FAILED'>;
+
+  it('should keep the known literals as distinct, non-collapsed members', () => {
+    // The literals survive alongside the open `string & {}` member rather than
+    // being eagerly collapsed into plain `string` – this is what preserves the
+    // editor suggestions. (tstyche has no completions matcher, so we pin the
+    // structural shape that makes the suggestions possible, not the suggestions.)
+    // Load-bearing assertion: it fails if the union ever collapses to plain `string`.
+    expect<Status>().type.toBe<'SUCCESS' | 'PENDING' | 'FAILED' | (string & Record<never, never>)>();
+  });
+
+  it('should accept the known string literals', () => {
+    expect<'SUCCESS'>().type.toBeAssignableTo<Status>();
+    expect<'PENDING'>().type.toBeAssignableTo<Status>();
+  });
+
+  it('should stay open to any string', () => {
+    expect<'anything else'>().type.toBeAssignableTo<Status>();
+    expect<string>().type.toBeAssignableTo<Status>();
+    // ...and is itself just a string (offers no safety beyond `string`)
+    expect<Status>().type.toBeAssignableTo<string>();
+  });
+
+  it('should raise an error for non-string type arguments', () => {
+    expect<LiteralStringUnion<number>>().type.toRaiseError();
+    expect<LiteralStringUnion<boolean>>().type.toRaiseError();
+  });
+
+  // Edge case
+  it('should reduce to the open string member when given never', () => {
+    expect<LiteralStringUnion<never>>().type.toBe<string & Record<never, never>>();
+  });
+
+  // Edge case
+  it('should degenerate to (be mutually assignable with) plain string when given a generic string', () => {
+    expect<LiteralStringUnion<string>>().type.toBeAssignableTo<string>();
+    expect<string>().type.toBeAssignableTo<LiteralStringUnion<string>>();
+  });
+
+  // Edge case
+  it('should degenerate the same way when the literal set already contains a bare string', () => {
+    expect<LiteralStringUnion<'a' | string>>().type.toBeAssignableTo<string>();
+    expect<string>().type.toBeAssignableTo<LiteralStringUnion<'a' | string>>();
   });
 });


### PR DESCRIPTION
## What

Adds `LiteralStringUnion<Literals extends string>` — a union of known string literals that **still accepts any string**, keeping the literals visible as editor suggestions:

```ts
type Status = LiteralStringUnion<'SUCCESS' | 'PENDING' | 'FAILED'>;
let a: Status = 'SUCCESS';   // suggested in the editor
let b: Status = 'anything';  // still allowed
```

## Why

It is the string-pinned form of [`type-fest`](https://github.com/sindresorhus/type-fest)'s `LiteralStringUnion` (`LiteralUnion<T, string>`) plus an `extends string` constraint — vendored, not depended on, with `@see` attribution, matching the existing `Simplify` / `IsEmptyObject` precedent. It is the natural counterpart to the existing `NonGenericString`, which instead *rejects* generic `string`.

It is a developer-experience helper: the type is `string`-equivalent, so it gives no type-safety, narrowing, or exhaustiveness guarantees over `string` — use a closed union when you need those (documented in the JSDoc).

## Commits

1. `chore:` — narrows `engines.typescript` to `>=5.9` and adds `ignoreBinaries: ["jq"]` to knip. This unblocks CI: a newer `@voxpelli/tsconfig` dropped its `<5.9` TS peer, so `installed-check` required the narrower engine; `jq` (used by `test:tstyche`) is a system binary knip can't resolve. `>=5.9` (not `>=5.9.0`) satisfies both `installed-check` and tstyche's `--target`, which rejects patch-level ranges. *(Each commit is independently CI-green.)*
2. `feat:` — the type, JSDoc, tests, and README entry.

## Tests

`typetests/string-types.test.ts` covers: literals preserved (load-bearing non-collapse guard), literals accepted, stays open to any string, constraint rejection (`<number>`/`<boolean>` raise errors), and the `<never>` / `<string>` / `<'a' | string>` degenerate cases. The autocomplete benefit itself is untestable in tstyche (no completions matcher), so the tests pin the structural invariants that make it possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)