### PR TITLE
chore(deps): bundle dependency updates

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://unpkg.com/knip@6/schema.json",
   "entry": ["index.d.ts"],
   "ignore": ["**/typetests/**/*.test.ts"],
   "ignoreBinaries": ["jq"]

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "npm-run-all2": "^8.0.4",
     "tstyche": "^6.2.0",
     "type-coverage": "^2.29.7",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "validate-conventional-commit": "^1.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "test": "run-s check test:*"
   },
   "devDependencies": {
-    "@types/node": "^20.19.33",
+    "@types/node": "^20.19.41",
     "@voxpelli/eslint-config": "^23.0.0",
-    "@voxpelli/tsconfig": "^16.1.0",
+    "@voxpelli/tsconfig": "^16.2.1",
     "eslint": "^9.39.2",
     "husky": "^9.1.7",
     "installed-check": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "installed-check": "^10.0.0",
-    "knip": "^5.83.1",
+    "knip": "^6.15.0",
     "npm-run-all2": "^8.0.4",
     "tstyche": "^6.2.0",
     "type-coverage": "^2.29.7",

--- a/package.json
+++ b/package.json
@@ -21,16 +21,16 @@
     "lib/*.d.ts"
   ],
   "scripts": {
+    "check": "run-p check:* --continue-on-error",
     "check:installed-check": "installed-check -i tstyche",
     "check:knip": "knip",
     "check:lint": "eslint",
     "check:tsc": "tsc",
-    "check:type-test": "tstyche",
     "check:type-coverage": "type-coverage --detail --strict --at-least 98 --ignore-files 'test/*'",
-    "check": "run-p check:* --continue-on-error",
+    "check:type-test": "tstyche",
     "prepare": "husky",
-    "test:tstyche": "tstyche --target \"$(jq -r '.engines.typescript' package.json)\"",
-    "test": "run-s check test:*"
+    "test": "run-s check test:*",
+    "test:tstyche": "tstyche --target \"$(jq -r '.engines.typescript' package.json)\""
   },
   "devDependencies": {
     "@types/node": "^20.19.41",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   },
   "devDependencies": {
     "@types/node": "^20.19.41",
-    "@voxpelli/eslint-config": "^23.0.0",
+    "@voxpelli/eslint-config": "^25.1.0",
     "@voxpelli/tsconfig": "^16.2.1",
-    "eslint": "^9.39.2",
+    "eslint": "^9.39.4",
     "husky": "^9.1.7",
     "installed-check": "^10.0.0",
     "knip": "^5.83.1",

--- a/typetests/declaration-types.test.ts
+++ b/typetests/declaration-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
 import type {
   AnyDeclaration,

--- a/typetests/function-types.test.ts
+++ b/typetests/function-types.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
 import type {
-  ParametersWithoutTheFirst,
   FunctionWithoutFirstParameter,
+  ParametersWithoutTheFirst,
 } from '../index.js';
 
 describe('ParametersWithoutTheFirst', () => {

--- a/typetests/object-types.test.ts
+++ b/typetests/object-types.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
 import type {
+  IsEmptyObject,
   ObjectEntries,
   ObjectEntry,
   ObjectFromEntries,
   PartialKeys,
   UnknownObjectEntry,
-  IsEmptyObject,
 } from '../index.js';
 
 describe('ObjectEntry', () => {

--- a/typetests/string-types.test.ts
+++ b/typetests/string-types.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
 import type {
+  LiteralStringUnion,
   NonGenericString,
   NonGenericStringArray,
-  LiteralStringUnion,
 } from '../index.js';
 
 describe('NonGenericString', () => {

--- a/typetests/util-types.test.ts
+++ b/typetests/util-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
 import type { Equal, MaybePromised, Simplify } from '../index.js';
 

--- a/typetests/verify-types.test.ts
+++ b/typetests/verify-types.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'tstyche';
+import { describe, expect, it } from 'tstyche';
 
-import type { VerifySuperset, VerifyObjectHasTypeProperty } from '../index.js';
+import type { VerifyObjectHasTypeProperty, VerifySuperset } from '../index.js';
 
 describe('VerifySuperset', () => {
   it('should accept superset that extends base type', () => {


### PR DESCRIPTION
Recreates the wanted Renovate dependency updates as atomic commits on top of the fixed `main` (so they're CI-green), to bundle them into the 4.2.0 release. Bypasses the stale-based Renovate PRs (#28–#33), which were red only because they branch from pre-CI-fix `main`.

All updates are **dev-only** — this is a types-only package, so none affect consumers.

## Included (each commit validated green independently)
- `chore(deps)`: `@voxpelli/tsconfig` ^16.2.1, `@types/node` ^20.19.41 (stays v20)
- `chore(deps)`: `typescript` ~6.0.3 — `engines.typescript` stays `>=5.9` (types still validate on 5.9 via the tstyche matrix)
- `chore(deps)`: `@voxpelli/eslint-config` ^25.1.0 + `eslint` ^9.39.4
- `style`: `eslint --fix` for config-25's new sort rules
- `chore(deps)`: `knip` ^6.15.0 (+ `.knip.jsonc` schema → knip@6)

## Deliberately NOT included
- **eslint 10** — `@voxpelli/eslint-config@25` peers `eslint ^9.38.0`; eslint 10 isn't supported until the config ships an eslint-10 major. (Supersedes #28/#33's eslint bump.)
- **npm-run-all2 v9** (#30) and **tstyche v7** (#27 / #31) — deferred to a follow-up.

## Follow-up
After merge: close superseded #28/#29/#32/#33; leave #27/#30/#31 open. release-please will fold these into the 4.2.0 changelog (#35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)